### PR TITLE
Set ContinuousIntegrationBuild during CICD

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup> 
+
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Set `ContinuousIntegrationBuild` to fix `Deterministic` flag in Nuget

see: https://mitchelsellers.com/blog/article/net-5-deterministic-builds-source-linking